### PR TITLE
Fix invalid check for username existance (relates to #18)

### DIFF
--- a/routes/api/user/login.js
+++ b/routes/api/user/login.js
@@ -26,9 +26,10 @@ router.post('/', (req, res) => {
       res.end();
       return;
     }
-    if (user == null) {
+    if (user === null) {
       res.send({ success: false, err: 'username does not exist' });
       res.end();
+      return;
     }
     crypto.checkPassword(password, user.hash).then((success) => {
       if (success) {

--- a/routes/api/user/login.js
+++ b/routes/api/user/login.js
@@ -26,7 +26,7 @@ router.post('/', (req, res) => {
       res.end();
       return;
     }
-    if (user === null) {
+    if (user == null) {
       res.send({ success: false, err: 'username does not exist' });
       res.end();
     }


### PR DESCRIPTION
This should hopefully fix #18. ~~The issue here is that the comparison for user existence uses the `===` operator instead of the `==` operator, which is required to check against `null`, a different type.~~

EDIT: I'm dumb, the actual issue is that the check for `user === null` does not return