### PR TITLE
Add email to authentication and registration

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -5,6 +5,8 @@ const User = new mongoose.Schema({
   hash: String,
   salt: String,
   teamId: String,
+  email: String,
+  email_confirmed: Boolean
 });
 
 module.exports = mongoose.model('user', User);

--- a/models/user.js
+++ b/models/user.js
@@ -6,7 +6,7 @@ const User = new mongoose.Schema({
   salt: String,
   teamId: String,
   email: String,
-  email_confirmed: Boolean
+  confirmedEmail: Boolean
 });
 
 module.exports = mongoose.model('user', User);

--- a/routes/api/user/register.js
+++ b/routes/api/user/register.js
@@ -40,7 +40,7 @@ router.post('/', (req, res) => {
             email,
             hash: hashedPassword,
             teamId: null,
-            email_confirmed: false
+            confirmedEmail: false
           });
           // TODO: We need to confirm emails somehow and add more checks for email validation for some other things, where deemed necessary.
           user.save((saveE, savedUser) => {

--- a/tests/postman/rgbctf.postman_collection.json
+++ b/tests/postman/rgbctf.postman_collection.json
@@ -21,7 +21,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"name\": \"testUser\",\n    \"password\": \"testPassword\"\n}",
+					"raw": "{\n    \"name\": \"testUser\",\n    \"email\": \"testUser@example.com\",\n    \"password\": \"testPassword\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"


### PR DESCRIPTION
This change does NOT handle confirmation, however, I did add a `confirmedEmail` field in the schema which is set by default to false upon registration.
The API for login is the same, however an email can be specified, and will be preferred when present. The email can also stand in for a username for login.
The API for registry now requires an `email` field, which must be a valid email.