### PR TITLE
Add GitHub actions auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+dependencies:
+- any: ['package.json', 'package-lock.json']
+
+documentation:
+- any: ['**/*.md']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,4 @@
-dependencies:
-- any: ['package.json', 'package-lock.json']
+dependencies: package.json
 
 documentation:
-- any: ['**/*.md']
+- /**/*.md

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,12 @@
+name: Auto-label dependency or documentation PRs
+on: [pull_request]
+
+jobs:
+  label:
+    
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This will auto-label documentation PRs (ones that edit any `.md` files as of now, but we can add more paths if we need to) and dependency PRs (ones that edit `package.json` and `package-lock.json`)